### PR TITLE
Docs & Docker: add Dockerfiles, compose, container-friendly Airflow DAG

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.venv/
+__pycache__/
+*.pyc
+*.DS_Store
+.git/
+.gitignore
+.airflow/
+airflow/
+.env
+data/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  python-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps (best-effort)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+
+      - name: Compile Python files
+        run: |
+          python -m py_compile scripts/flight_delays_s3.py
+
+      - name: Parse Airflow DAG (syntax check)
+        run: |
+          python - << 'PY'
+          import ast
+          with open('airflow/dags/morningflow_spark.py','r') as f:
+              ast.parse(f.read())
+          print('DAG parsed OK')
+          PY
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Spark job image
+        run: docker build -f Dockerfile -t morningflow:ci .
+
+      - name: Build Airflow image
+        run: docker build -f Dockerfile.airflow -t morningflow-airflow:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Base: Python 3.11 with Java 11
+FROM openjdk:11-jre-slim AS base
+
+# Install Python 3.11 and system deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.11 python3.11-venv python3-pip curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Workdir
+WORKDIR /app
+
+# Copy and install Python deps
+COPY requirements.txt ./
+RUN python3.11 -m pip install --upgrade pip \
+ && pip install -r requirements.txt
+
+# Copy code
+COPY scripts/ ./scripts/
+
+# Default bucket can be overridden via --env BUCKET=...
+ENV BUCKET="morningflow"
+
+# Run the job (override args at runtime if desired)
+# Example: docker run --rm -e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=... \
+#          -e AWS_REGION=us-west-2 -e BUCKET=morningflow image:tag
+ENTRYPOINT ["python3.11", "scripts/flight_delays_s3.py"]
+CMD ["--bucket", "${BUCKET}"]

--- a/Dockerfile.airflow
+++ b/Dockerfile.airflow
@@ -1,0 +1,17 @@
+# Airflow image with Java 11 and Python dependencies for Spark job
+FROM apache/airflow:2.9.3-python3.11
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-11-jre-headless \
+ && rm -rf /var/lib/apt/lists/*
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+USER airflow
+
+# Python dependencies (Spark, boto3, etc.)
+COPY requirements.txt /requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt
+
+# Default envs (overridable at runtime)
+ENV PROJECT_DIR=/opt/airflow/morningflow \
+    BUCKET=morningflow

--- a/README.md
+++ b/README.md
@@ -1,63 +1,62 @@
-# MorningFlow
+# MorningFlow (Spark + Amazon S3)
 
----
+A simple, reproducible example that reads a public flight delays file, processes it with Apache Spark, and saves summary results back to your Amazon S3 bucket.
 
-# MorningFlow - Spark + S3 (Flight Delays)
+You don’t need to be a programmer to run it. Just follow the steps below.
 
-Beginner-friendly Spark job that reads the Databricks flight delays dataset from S3, computes aggregations, and writes results back to S3. Includes `.env` support and AWS preflight checks.
+## What you’ll get
+- A working Spark job you can run any time
+- Results saved in your S3 bucket (easy to view or download)
+- Optional scheduling with Airflow so it runs every morning
+- Optional email alerts on success/failure
 
-## Quick Start
+## What you need (macOS)
+- An AWS account and an S3 bucket name (example we use: `morningflow`)
+- Homebrew (software installer for Mac)
+- Java 11, Python 3.11, AWS CLI
+
+## 1) One‑time setup (copy/paste)
+Open Terminal and run these in order:
+
 ```bash
-# 1) Create venv & install
+# Go to the project folder
 cd "/Users/edwardjr/Downloads/upwork /Engineering/MorningFlow"
+
+# Create a private Python environment and install tools
 python3.11 -m venv .venv && source .venv/bin/activate
 python -m pip install --upgrade pip
 pip install pyspark==3.5.1 pandas==2.2.2 pyarrow==16.1.0 loguru==0.7.2 boto3==1.34.148 delta-spark==3.2.0 python-dotenv==1.0.1
 
-# 2) Java 11 and AWS CLI
+# Install Java 11 and AWS command line
 brew install --cask temurin@11 && export JAVA_HOME=$(/usr/libexec/java_home -v11)
 brew install awscli
-
-# 3) Credentials (choose ONE)
-aws configure --profile morningflow && export AWS_PROFILE=morningflow
-# or
-printf "AWS_ACCESS_KEY_ID=...\nAWS_SECRET_ACCESS_KEY=...\nAWS_REGION=<region>\nAWS_DEFAULT_REGION=<region>\nBUCKET=morningflow\n" > .env
-set -a; source .env; set +a
-
-# 4) Upload dataset
-mkdir -p data
-curl -L -o data/departuredelays.csv https://raw.githubusercontent.com/databricks/LearningSparkV2/master/databricks-datasets/learning-spark-v2/flights/departuredelays.csv
-aws s3 cp data/departuredelays.csv s3://morningflow/flights/raw/departuredelays.csv
-
-# 5) Run
-python scripts/flight_delays_s3.py --bucket morningflow --sample 100000
 ```
 
-## Prerequisites (macOS)
-- Homebrew
-- Python 3.11 (venv)
-- Java 11 (Temurin)
-- AWS CLI v2
+## 2) Connect to your AWS account
+Pick ONE of the two ways below.
 
-## Configure AWS (profile or .env)
-- Profile (recommended):
+Option A: Use an AWS profile (recommended)
 ```bash
-aws configure --profile morningflow
+aws configure --profile morningflow   # enter Access Key, Secret, region
 export AWS_PROFILE=morningflow
 aws sts get-caller-identity
 ```
-- `.env` (gitignored):
+
+Option B: Use a .env file in this folder
 ```bash
+# Create file named .env with your details (one per line)
 AWS_ACCESS_KEY_ID=YOUR_KEY
 AWS_SECRET_ACCESS_KEY=YOUR_SECRET
-AWS_SESSION_TOKEN=
-AWS_REGION=<your-region>
-AWS_DEFAULT_REGION=<your-region>
+AWS_REGION=us-west-2
+AWS_DEFAULT_REGION=us-west-2
 BUCKET=morningflow
-```
-Load it: `set -a; source .env; set +a`
 
-## Minimal IAM policy
+# Load it for the current terminal session
+set -a; source .env; set +a
+aws sts get-caller-identity
+```
+
+Minimum S3 permissions for your user
 ```json
 {
   "Version": "2012-10-17",
@@ -68,56 +67,131 @@ Load it: `set -a; source .env; set +a`
 }
 ```
 
-## Run the Spark job (full)
+## 3) Put the sample data in your S3 bucket
+```bash
+mkdir -p data
+curl -L -o data/departuredelays.csv \
+  https://raw.githubusercontent.com/databricks/LearningSparkV2/master/databricks-datasets/learning-spark-v2/flights/departuredelays.csv
+aws s3 cp data/departuredelays.csv s3://morningflow/flights/raw/departuredelays.csv
+```
+
+## 4) Run the job
 ```bash
 source .venv/bin/activate
 export JAVA_HOME=$(/usr/libexec/java_home -v11)
-python scripts/flight_delays_s3.py --bucket morningflow --profile morningflow --region <bucket-region>
+python scripts/flight_delays_s3.py --bucket morningflow
 ```
-Outputs:
-- `s3://morningflow/flights/output/avg_delay_by_origin/`
-- `s3://morningflow/flights/output/avg_delay_by_destination/`
-- `s3://morningflow/flights/output/route_stats/`
-- `s3://morningflow/flights/output/daily_delay_counts/`
 
-## Airflow (schedule daily 6 AM PT)
-- DAG: `airflow/dags/morningflow_spark.py`
-- Assumes this project path and a working `.venv`.
-- Quick local run (system Airflow):
+What happens:
+- The script reads your file from `s3://morningflow/flights/raw/departuredelays.csv`
+- It computes summaries (average delays, route stats, etc.)
+- It writes results to `s3://morningflow/flights/output/` in folders:
+  - `avg_delay_by_origin/`
+  - `avg_delay_by_destination/`
+  - `route_stats/`
+  - `daily_delay_counts/`
+
+Check in S3 (Terminal):
+```bash
+aws s3 ls s3://morningflow/flights/output/
+```
+
+## 5) (Optional) Schedule daily with Airflow
+If you want this to run every morning at 6 AM PT.
+
+Install Airflow and start it:
 ```bash
 pip install "apache-airflow==2.9.3" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt"
-airflow db init
 export AIRFLOW_HOME=~/airflow
+airflow db migrate
 mkdir -p "$AIRFLOW_HOME/dags"
 cp -R airflow/dags/* "$AIRFLOW_HOME/dags/"
-airflow users create --role Admin --username admin --password admin --firstname a --lastname d --email a@d
 airflow webserver -p 8080 &
 airflow scheduler &
 ```
-- In UI: enable `morningflow_flight_delays` (runs 6 AM PT daily). To test now: trigger DAG manually.
 
-## Challenges we encountered (and fixes)
-- Missing AWS CLI / Java 11 → install via Homebrew and set `JAVA_HOME`.
-- Credentials not loaded → use AWS profile or `.env`.
-- AccessDenied (403) → add ListBucket/GetBucketLocation + object R/W.
-- PATH_NOT_FOUND → upload CSV to the expected S3 prefix.
-- Date parsing in Spark ≥3 → handle MMddHHmm with assumed year.
-- .env formatting → one variable per line.
+Open the Airflow UI at http://localhost:8080, find the DAG named `morningflow_flight_delays`, turn it on, and click “Trigger DAG” to run immediately.
 
-## Top 3 long‑term real‑world use cases
-- Airline operations analytics (route/airport KPIs, alerts, staffing).
-- Data lake inputs for ML (delay prediction, optimization, forecasting).
-- BI/reporting via Athena/Databricks/Redshift Spectrum over S3/Delta.
-
-## GitHub
+Email alerts (optional)
 ```bash
-git init
-git add .
-git commit -m "MorningFlow: Spark + S3 flight delays job + README"
-git branch -M main
-git remote add origin git@github.com:<you>/<repo>.git
-git push -u origin main
+# Who should receive emails
+export ALERT_EMAIL="you@example.com"
+# Get success emails too (optional)
+export EMAIL_ON_SUCCESS=true
+
+# Set your SMTP details (example for Gmail with an App Password)
+export AIRFLOW__SMTP__SMTP_HOST="smtp.gmail.com"
+export AIRFLOW__SMTP__SMTP_PORT="587"
+export AIRFLOW__SMTP__SMTP_STARTTLS=True
+export AIRFLOW__SMTP__SMTP_USER="your@gmail.com"
+export AIRFLOW__SMTP__SMTP_PASSWORD="your_app_password"
+export AIRFLOW__SMTP__SMTP_MAIL_FROM="your@gmail.com"
+```
+Restart Airflow after setting these.
+
+## 6) (Optional) Run everything with Docker
+No manual Python/Java installs. Docker will run the job in a container.
+
+Build the image (do this once):
+```bash
+docker build -t morningflow:latest .
 ```
 
-## Next
-- Switch Airflow to Docker Compose or Databricks Jobs if preferred.
+Run using environment variables (no profile needed):
+```bash
+docker run --rm \
+  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+  -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
+  -e AWS_REGION=$AWS_REGION \
+  -e BUCKET=morningflow \
+  morningflow:latest --bucket morningflow
+```
+
+Or run using your local AWS profile (mount your creds):
+```bash
+# Linux/macOS path to your AWS credentials/config
+# (~/.aws must exist and contain your profile)
+docker run --rm \
+  -v $HOME/.aws:/root/.aws:ro \
+  -e AWS_PROFILE=morningflow \
+  -e BUCKET=morningflow \
+  morningflow:latest --bucket morningflow
+```
+
+### Docker Compose: Airflow in containers
+Start Airflow (webserver + scheduler) in Docker, using the DAG in this repo:
+```bash
+docker compose up -d airflow-init
+docker compose up -d airflow-webserver airflow-scheduler
+# Open: http://localhost:8080 (user: admin / pass: admin)
+```
+- To run the Spark job once in a container:
+```bash
+docker compose run --rm spark-run --bucket ${BUCKET:-morningflow}
+```
+- To stop everything:
+```bash
+docker compose down
+```
+
+## Reproduce on another Mac
+```bash
+# 1) Clone the repo
+git clone https://github.com/Hybr1d758/MorningFlow.git
+cd MorningFlow
+
+# 2) Follow steps 1–4 above, or use Docker (step 6)
+```
+
+## Common problems and quick fixes
+- “Unable to locate credentials” → Run `aws configure --profile morningflow` or load `.env`.
+- “AccessDenied (403)” → Your IAM user needs the S3 permissions shown above.
+- “Unable to locate a Java Runtime” → Install Java 11 and run `export JAVA_HOME=$(/usr/libexec/java_home -v11)`.
+- “File not found” → Make sure the CSV is uploaded to `s3://<bucket>/flights/raw/departuredelays.csv`.
+
+## What this project is doing (in plain English)
+- We download a sample CSV of flight departures and delays.
+- Spark reads the CSV and cleans it.
+- We calculate useful summaries (like average delay per airport).
+- The results are stored in your S3 bucket so you can view or analyze them later.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3.8"
+
+x-airflow-common: &airflow-common
+  build:
+    context: .
+    dockerfile: Dockerfile.airflow
+  environment:
+    AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+    AIRFLOW__WEBSERVER__WORKERS: "1"
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    # Email alerts (optional)
+    ALERT_EMAIL: ${ALERT_EMAIL}
+    EMAIL_ON_SUCCESS: ${EMAIL_ON_SUCCESS}
+    # AWS (either profile via mounted ~/.aws or env vars)
+    AWS_PROFILE: ${AWS_PROFILE}
+    AWS_REGION: ${AWS_REGION}
+    BUCKET: ${BUCKET:-morningflow}
+    PROJECT_DIR: /opt/airflow/morningflow
+  volumes:
+    - ./airflow/dags:/opt/airflow/dags
+    - ./:/opt/airflow/morningflow
+    - ~/.aws:/home/airflow/.aws:ro
+  user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-0}"
+
+services:
+  airflow-init:
+    <<: *airflow-common
+    command: bash -c "airflow db migrate && airflow users create --role Admin --username admin --password admin --firstname a --lastname d --email a@d || true"
+
+  airflow-webserver:
+    <<: *airflow-common
+    command: airflow webserver
+    ports:
+      - "8080:8080"
+    depends_on:
+      - airflow-init
+
+  airflow-scheduler:
+    <<: *airflow-common
+    command: airflow scheduler
+    depends_on:
+      - airflow-webserver
+
+  spark-run:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+      AWS_REGION: ${AWS_REGION}
+      BUCKET: ${BUCKET:-morningflow}
+    command: ["--bucket", "${BUCKET:-morningflow}"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pyspark==3.5.1
+pandas==2.2.2
+pyarrow==16.1.0
+loguru==0.7.2
+boto3==1.34.148
+minio==7.2.7
+delta-spark==3.2.0
+python-dotenv==1.0.1


### PR DESCRIPTION

Summary
- Add Dockerfile to run Spark job in a container
- Add Dockerfile.airflow and docker-compose.yml for Airflow (webserver + scheduler) in containers
- Make DAG container-friendly (PROJECT_DIR env, no venv activation)
- Email-only alerts with env config
- Rewrite README for non-programmers; add Docker/Compose steps

What’s included
- Dockerfile, Dockerfile.airflow, docker-compose.yml, requirements.txt
- airflow/dags/morningflow_spark.py updates
- README: step-by-step setup, Docker/Compose instructions

How to test
1) Build Spark image: docker build -t morningflow:latest .
2) One-off job: docker compose run --rm spark-run --bucket ${BUCKET:-morningflow}
3) Airflow in Docker:
   - docker compose up -d airflow-init
   - docker compose up -d airflow-webserver airflow-scheduler
   - open http://localhost:8080, enable and trigger morningflow_flight_delays
4) Verify outputs in S3: aws s3 ls s3://<bucket>/flights/output/
5) (Optional) Email alerts: set ALERT_EMAIL and SMTP env; re-run

Checklist
- [ ] Image builds locally
- [ ] spark-run completes and writes to S3
- [ ] Airflow webserver reachable
- [ ] DAG runs successfully from UI
- [ ] Email alert received (if configured)
- [ ] README feels clear to a non-programmer
